### PR TITLE
Backend CD: Display branch information in workflow

### DIFF
--- a/.github/workflows/backend-cd.yml
+++ b/.github/workflows/backend-cd.yml
@@ -91,13 +91,14 @@ jobs:
           ref: ${{ vars.TARGET_BRANCH }}
 
       - name: Merge main branch into target branch
-        run: git merge origin/main
-
-      - name: Commit changes in Dockerrun.aws.json
         run: |
           echo "Branch ref: ${{ github.ref }}"
           echo "Target branch: ${{ vars.TARGET_BRANCH }}"
           git branch
+          git merge origin/main
+
+      - name: Commit changes in Dockerrun.aws.json
+        run: |
           git config --local user.email "github-actions[bot]@users.noreply.github.com"
           git config --local user.name "github-actions[bot]"
           git commit -a -m "Update Dockerrun.aws.json with new api image tag ${{ steps.build-number.outputs.BUILD_NUMBER }}"


### PR DESCRIPTION
### Type:

Enhancement

### Description:

This PR refactors the backend deployment workflow to display branch information in the "Merge main branch into target branch" step. This is achieved by adding echo commands to print the branch reference and target branch. The branch is also displayed using the git branch command. The main branch is then merged into the target branch.

### Main Files Walkthrough:

<details>
  <summary>files:</summary>

- `.github/workflows/backend-cd.yml`: This is the main file that has been modified in this PR. The changes include:
   - In the "Merge main branch into target branch" step, echo commands are added to print the branch reference and target branch. The current branch is also displayed using the git branch command.
   - The command to merge the main branch into the target branch is moved to after the branch information is displayed.
</details>