### PR TITLE
Backend CD: Implement Slack notifications

### DIFF
--- a/.github/workflows/backend-cd.yml
+++ b/.github/workflows/backend-cd.yml
@@ -91,7 +91,7 @@ jobs:
 
       - name: Fetch changes from remote main branch
         run: |
-          git fetch origin main ${{ vars.TARGET_BRANCH }}
+          git fetch origin main
           git branch
           git branch -r
 

--- a/.github/workflows/backend-cd.yml
+++ b/.github/workflows/backend-cd.yml
@@ -31,6 +31,14 @@ jobs:
       run:
         working-directory: ./backend
     steps:
+      - name: Send Slack notification about deployment start
+        run: >
+          curl -X POST -H 'Content-type: application/json' --data '
+          {
+            "text": "Backend deployment started :spring-boot: :radical_rocket: :fingers_crossed:",
+          }
+          ' "${{ secrets.SLACK_WEBHOOK_URL }}"
+
       - name: Check out repository code
         uses: actions/checkout@v4
         with:
@@ -53,6 +61,14 @@ jobs:
         id: build-number
         run: echo "BUILD_NUMBER=$(date '+%Y%m%d.%j.%H%M%S')" >> $GITHUB_OUTPUT
 
+      - name: Send Slack notification about maven build start
+        run: >
+          curl -X POST -H 'Content-type: application/json' --data '
+          {
+            "text": ":apache_maven: :container: Building with Maven and Jib Maven Plugin",
+          }
+          ' "${{ secrets.SLACK_WEBHOOK_URL }}"
+
       - name: Build, Package and Push Docker image with Maven
         env:
           ACTIVE_SPRING_PROFILES: test
@@ -69,6 +85,14 @@ jobs:
         run:
           mvn -B -ntp verify -Ddocker.image.tag=${{ steps.build-number.outputs.BUILD_NUMBER }}
 
+      - name: Send Slack notification about maven build end
+        run: >
+          curl -X POST -H 'Content-type: application/json' --data '
+          {
+            "text": ":apache_maven: Maven build completed. :docker: Image tag: ${{ steps.build-number.outputs.BUILD_NUMBER }} pushed to Docker Hub: https://hub.docker.com/r/${{ secrets.DOCKERHUB_USERNAME }}/pixshare-api",
+          }
+          ' "${{ secrets.SLACK_WEBHOOK_URL }}"  
+
       - name: Update api image tag in Dockerrun.aws.json with new build number
         run: |
           echo "Dockerrun.aws.json before image tag update:"
@@ -76,6 +100,14 @@ jobs:
           sed -i -E 's/(${{ secrets.DOCKERHUB_USERNAME }}\/pixshare-api:)([^"]*)/\1'"${{ steps.build-number.outputs.BUILD_NUMBER }}"'/' Dockerrun.aws.json
           echo "Dockerrun.aws.json after image tag update:"
           cat Dockerrun.aws.json
+
+      - name: Send Slack notification about elastic beanstalk deployment start
+        run: >
+          curl -X POST -H 'Content-type: application/json' --data '
+          {
+            "text": ":aws: Deployment to :aws_eb: Elastic Beanstalk started",
+          }
+          ' "${{ secrets.SLACK_WEBHOOK_URL }}"
 
       - name: Deploy to Elastic Beanstalk
         uses: einaregilsson/beanstalk-deploy@v21
@@ -88,6 +120,14 @@ jobs:
           version_description: ${{ github.sha }}
           region: ${{ secrets.AWS_EB_REGION }}
           deployment_package: backend/Dockerrun.aws.json
+
+      - name: Send Slack notification about repo commit start
+        run: >
+          curl -X POST -H 'Content-type: application/json' --data '
+          {
+            "text": ":merge: Committing to :github-logo: pix-share-social-app-fullstack-react-springboot repository",
+          }
+          ' "${{ secrets.SLACK_WEBHOOK_URL }}"
 
       - name: Fetch changes from remote main branch
         run: |
@@ -120,3 +160,25 @@ jobs:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           branch: ${{ vars.TARGET_BRANCH }}
           force: false  # Avoid force pushing
+
+      - name: Send Slack notification about elastic beanstalk deployment and repo commit end
+        run: >
+          curl -X POST -H 'Content-type: application/json' --data '
+          {
+            "text": "Deployment and commit completed :completed: :partytime: - ${{ secrets.AWS_EB_ENVIRONMENT_URL  }}",
+          }
+          ' "${{ secrets.SLACK_WEBHOOK_URL }}"
+
+      - name: Send Slack notification about job end
+        if: always()
+        run: |
+          STATUS_MESSAGE=":question: Unknown"
+          if [ "${{ job.status }}" = "success" ]; then
+                TEXT=":github-check-mark: Success"
+          elif [ "${{ job.status }}" = "failure" ]; then
+                TEXT=":github-changes-requested: Failed"            
+          elif [ "${{ job.status }}" = "cancelled" ]; then
+                TEXT=":gitlab-warning: Cancelled"
+          fi
+
+          curl -X POST -H 'Content-type: application/json' --data '{ "text": "Job Run Id: :github-actions: ${{ github.run_id }} Job Status: $STATUS_MESSAGE" }' "${{ secrets.SLACK_WEBHOOK_URL }}"

--- a/backend/Dockerrun.aws.json
+++ b/backend/Dockerrun.aws.json
@@ -3,7 +3,7 @@
   "containerDefinitions": [
     {
       "name": "pixshare-api",
-      "image": "projcodehub/pixshare-api:20240325.085.051123",
+      "image": "projcodehub/pixshare-api:20240325.085.092422",
       "essential": true,
       "memory": 512,
       "portMappings": [


### PR DESCRIPTION
### Type:

Feature

### Description:

This PR introduces Slack notifications into the backend continuous deployment (CD) workflow. The notifications are sent at various stages of the deployment process, providing real-time updates on the progress of the deployment. This includes notifications for the start of the deployment, the start and end of the Maven build, the start of the Elastic Beanstalk deployment, the start of the repo commit, and the end of the deployment and repo commit. Additionally, a final notification is sent at the end of the job, indicating the status of the job (success, failure, or cancelled).

### Main Files Walkthrough:

<details>
  <summary>files:</summary>

- `.github/workflows/backend-cd.yml`: This is the GitHub Actions workflow file for backend continuous deployment. New steps have been added to send Slack notifications at various stages of the deployment process. The notifications are sent using the 'curl' command and the Slack webhook URL stored in the GitHub secrets.

- `backend/Dockerrun.aws.json`: This file contains the AWS Elastic Beanstalk Docker run configuration. The 'image' field has been updated with a new Docker image tag.
</details>