### PR TITLE
Backend CD: Enhance Slack notifications

### DIFF
--- a/.github/workflows/backend-cd.yml
+++ b/.github/workflows/backend-cd.yml
@@ -31,14 +31,6 @@ jobs:
       run:
         working-directory: ./backend
     steps:
-      - name: Send Slack notification about deployment start
-        run: >
-          curl -X POST -H 'Content-type: application/json' --data '
-          {
-            "text": "Backend deployment started :spring-boot: :radical_rocket: :fingers_crossed:",
-          }
-          ' "${{ secrets.SLACK_WEBHOOK_URL }}"
-
       - name: Check out repository code
         uses: actions/checkout@v4
         with:
@@ -50,6 +42,14 @@ jobs:
           distribution: 'temurin'
           java-version: '17'
           cache: 'maven'
+
+      - name: Send Slack notification about deployment start
+        run: >
+          curl -X POST -H 'Content-type: application/json' --data '
+          {
+            "text": "Backend deployment started :spring-boot: :radical_rocket: :fingers_crossed:",
+          }
+          ' "${{ secrets.SLACK_WEBHOOK_URL }}"
 
       - name: Login to Docker Hub
         uses: docker/login-action@v3


### PR DESCRIPTION
### Type:

Improvement

### Description:

This PR focuses on improving the Slack notifications in the backend continuous deployment (CD) workflow. The change involves moving the step that sends a Slack notification about the start of the deployment. Previously, this step was executed before checking out the repository code. Now, it is executed after the repository code has been checked out and Java has been set up. This ensures that the notification is sent only when the initial setup steps have been successfully completed.

### Main Files Walkthrough:

<details>
  <summary>files:</summary>

- `.github/workflows/backend-cd.yml`: This is the GitHub Actions workflow file for backend continuous deployment. The modification involves moving the Slack notification step to a later point in the workflow.
</details>