### PR TITLE
Update EB config for frontend memory allocation

### DIFF
--- a/Dockerrun.aws.json
+++ b/Dockerrun.aws.json
@@ -5,7 +5,7 @@
       "name": "pixshare-react",
       "image": "projcodehub/pixshare-react:latest",
       "essential": false,
-      "memory": 192,
+      "memory": 100,
       "portMappings": [
         {
           "hostPort": 80,


### PR DESCRIPTION
### Type:

Configuration

### Description:

This PR updates the Elastic Beanstalk (EB) configuration for the frontend service, specifically reducing the memory allocation from 192 MB to 100 MB. This change is reflected in the `Dockerrun.aws.json` file, which is used by AWS EB to understand how to run our Docker containers.

### Main Files Walkthrough:

<details>
  <summary>files:</summary>

- `Dockerrun.aws.json`: This is the main file affected by this PR. It contains the configuration for our Docker containers that are run by AWS Elastic Beanstalk. The memory allocation for the 'pixshare-react' service has been reduced from 192 MB to 100 MB.
</details>