### PR TITLE
Frontend CD: Update multi-arch Docker build script

### DIFF
--- a/.ci-cd/scripts/docker_build_publish.sh
+++ b/.ci-cd/scripts/docker_build_publish.sh
@@ -2,8 +2,6 @@
 : "${REPO:?REPO not set or empty}"
 : "${TAG:?TAG not set or empty}"
 
-set -e
-
 docker buildx create --use
 
 docker buildx build \


### PR DESCRIPTION
### Type:

Enhancement

### Description:

This PR updates the Docker build script used in the Continuous Deployment of the frontend. The main change is the removal of the 'set -e' command, which causes the shell to exit if any invoked command exits with a non-zero status. This change may make the script more resilient to minor errors during the build process.

### Main Files Walkthrough:

<details>
  <summary>files:</summary>

- `.ci-cd/scripts/docker_build_publish.sh`: This is the main file affected by this PR. This is a shell script that is used to build and publish Docker images as part of the continuous deployment process. The changes in this PR affect how this script handles errors during the build process.
</details>