### PR TITLE
Update API Image Tag in Dockerrun.aws.json

### DIFF
--- a/Dockerrun.aws.json
+++ b/Dockerrun.aws.json
@@ -3,7 +3,7 @@
   "containerDefinitions": [
     {
       "name": "pixshare-api",
-      "image": "projcodehub/pixshare-api:20240405.096.090535",
+      "image": "projcodehub/pixshare-api:20240408.099.132146",
       "essential": true,
       "memory": 512,
       "portMappings": [


### PR DESCRIPTION
### Type:

Chore

### Description:

This PR updates the image tag of the 'pixshare-api' in the Dockerrun.aws.json file. The new image tag is '20240408.099.132146', replacing the old one '20240405.096.090535'. This update is necessary to ensure that the AWS Elastic Beanstalk environment uses the latest version of the 'pixshare-api' Docker image.

### Main Files Walkthrough:

<details>
  <summary>files:</summary>

- `Dockerrun.aws.json`: This is the AWS Elastic Beanstalk Docker run configuration file. In this file, the 'image' attribute in the 'containerDefinitions' array has been updated. This attribute specifies the Docker image to use for the 'pixshare-api' container.
</details>