### PR TITLE
Implement Basic auth with Vercel rewrite rules

### DIFF
--- a/frontend/vercel.json
+++ b/frontend/vercel.json
@@ -14,7 +14,7 @@
       ]         
     },
     {
-      "source": "/.*",
+      "source": "/(.*)",
       "destination": "/401.html",
       "statusCode": 401,
       "missing": [
@@ -28,7 +28,7 @@
   ],
   "headers": [
     {
-      "source": "/.*",
+      "source": "/(.*)",
       "missing": [
         {
           "type": "header",

--- a/frontend/vercel.json
+++ b/frontend/vercel.json
@@ -1,8 +1,10 @@
 {
+  "$schema": "https://openapi.vercel.sh/vercel.json",
   "rewrites": [
     {
       "source": "/([^.]+)",
       "destination": "/",
+      "statusCode": 200,
       "has": [
         {
           "type": "header",
@@ -14,12 +16,30 @@
     {
       "source": "/.*",
       "destination": "/401.html",
-      "headers": { "www-authenticate": "Basic realm=\"vercel-basic-auth\"" },
+      "statusCode": 401,
       "missing": [
         {
           "type": "header",
           "key": "authorization",
           "value": "Basic @VERCEL_BASIC_AUTH_TOKEN"
+        }
+      ]
+    }
+  ],
+  "headers": [
+    {
+      "source": "/.*",
+      "missing": [
+        {
+          "type": "header",
+          "key": "authorization",
+          "value": "Basic @VERCEL_BASIC_AUTH_TOKEN"
+        }
+      ],
+      "headers": [
+        {
+          "key": "www-authenticate",
+          "value": "Basic realm=\"vercel-basic-auth\""
         }
       ]
     }

--- a/frontend/vercel.json
+++ b/frontend/vercel.json
@@ -9,7 +9,7 @@
         {
           "type": "header",
           "key": "authorization",
-          "value": "Basic @VERCEL_BASIC_AUTH_TOKEN"
+          "value": "Basic $VERCEL_BASIC_AUTH_TOKEN"
         }
       ]         
     },
@@ -21,7 +21,7 @@
         {
           "type": "header",
           "key": "authorization",
-          "value": "Basic @VERCEL_BASIC_AUTH_TOKEN"
+          "value": "Basic $VERCEL_BASIC_AUTH_TOKEN"
         }
       ]
     }
@@ -33,7 +33,7 @@
         {
           "type": "header",
           "key": "authorization",
-          "value": "Basic @VERCEL_BASIC_AUTH_TOKEN"
+          "value": "Basic $VERCEL_BASIC_AUTH_TOKEN"
         }
       ],
       "headers": [

--- a/frontend/vercel.json
+++ b/frontend/vercel.json
@@ -2,7 +2,27 @@
   "rewrites": [
     {
       "source": "/([^.]+)",
-      "destination": "/"          
+      "destination": "/",
+      "status": 200,
+      "has": [
+        {
+          "type": "header",
+          "key": "authorization",
+          "value": "Basic @VERCEL_BASIC_AUTH_TOKEN"
+        }
+      ]         
+    },
+    {
+      "source": "/.*",
+      "status": 401,
+      "headers": { "www-authenticate": "Basic realm=\"vercel-basic-auth\"" },
+      "missing": [
+        {
+          "type": "header",
+          "key": "authorization",
+          "value": "Basic @VERCEL_BASIC_AUTH_TOKEN"
+        }
+      ]
     }
   ]    
 } 

--- a/frontend/vercel.json
+++ b/frontend/vercel.json
@@ -9,7 +9,7 @@
         {
           "type": "header",
           "key": "authorization",
-          "value": "Basic $VERCEL_BASIC_AUTH_TOKEN"
+          "value": "Basic d2ViX3VzZXI6M1hjSXRJbmdqM3RtM2FuIw=="
         }
       ]         
     },
@@ -21,7 +21,7 @@
         {
           "type": "header",
           "key": "authorization",
-          "value": "Basic $VERCEL_BASIC_AUTH_TOKEN"
+          "value": "Basic d2ViX3VzZXI6M1hjSXRJbmdqM3RtM2FuIw=="
         }
       ]
     }
@@ -33,7 +33,7 @@
         {
           "type": "header",
           "key": "authorization",
-          "value": "Basic $VERCEL_BASIC_AUTH_TOKEN"
+          "value": "Basic d2ViX3VzZXI6M1hjSXRJbmdqM3RtM2FuIw=="
         }
       ],
       "headers": [

--- a/frontend/vercel.json
+++ b/frontend/vercel.json
@@ -3,7 +3,6 @@
     {
       "source": "/([^.]+)",
       "destination": "/",
-      "status": 200,
       "has": [
         {
           "type": "header",
@@ -14,7 +13,7 @@
     },
     {
       "source": "/.*",
-      "status": 401,
+      "destination": "/401.html",
       "headers": { "www-authenticate": "Basic realm=\"vercel-basic-auth\"" },
       "missing": [
         {


### PR DESCRIPTION
### Type:

Feature

### Description:

This PR introduces Basic Authentication to the application by utilizing Vercel's rewrite and header rules. It ensures that only requests with the correct authorization header are allowed access to the main content, while all others are redirected to a 401 error page. This is achieved by modifying the 'vercel.json' configuration file.

### Main Files Walkthrough:

<details>
  <summary>files:</summary>

- `frontend/vercel.json`: This is the main file affected in this PR. Changes include:
  - Addition of a '$schema' property for Vercel configuration validation.
  - Modification of the existing rewrite rule to include a condition ('has') that checks for the presence of a specific Basic Auth header.
  - Addition of a new rewrite rule that redirects to a 401 error page if the required Basic Auth header is missing.
  - Addition of a response header rule that prompts the user for authentication credentials if the authorization header is missing.
</details>