### PR TITLE
Enhanced Authentication Error Handling and Security Configuration for Role-based Access Control

### DIFF
--- a/Dockerrun.aws.json
+++ b/Dockerrun.aws.json
@@ -1,7 +1,7 @@
 {
   "AWSEBDockerrunVersion": "1",
   "Image": {
-    "Name": "projcodehub/pixshare-api:20240617.169.052647",
+    "Name": "projcodehub/pixshare-api:20250526.146.232322",
     "Update": "true"
   },
   "Ports": [

--- a/Dockerrun.aws.json
+++ b/Dockerrun.aws.json
@@ -1,7 +1,7 @@
 {
   "AWSEBDockerrunVersion": "1",
   "Image": {
-    "Name": "projcodehub/pixshare-api:20250526.146.232322",
+    "Name": "projcodehub/pixshare-api:20250530.150.133953",
     "Update": "true"
   },
   "Ports": [

--- a/backend/src/main/java/com/pixshare/pixshareapi/exception/DefaultExceptionHandler.java
+++ b/backend/src/main/java/com/pixshare/pixshareapi/exception/DefaultExceptionHandler.java
@@ -53,7 +53,7 @@ public class DefaultExceptionHandler {
     @ExceptionHandler(InsufficientAuthenticationException.class)
     public ResponseEntity<ApiError> handleInsufficientAuthenticationException(InsufficientAuthenticationException e,
                                                                               HttpServletRequest request) {
-        HttpStatus status = HttpStatus.FORBIDDEN;
+        HttpStatus status = HttpStatus.UNAUTHORIZED;
         ApiError apiError = new ApiError(request.getRequestURI(),
                 e.getMessage(),
                 "INSUFFICIENT_AUTHENTICATION",
@@ -68,7 +68,7 @@ public class DefaultExceptionHandler {
                                                                   HttpServletRequest request) {
         HttpStatus status = HttpStatus.UNAUTHORIZED;
         ApiError apiError = new ApiError(request.getRequestURI(),
-                e.getMessage(),
+                "Invalid credentials. Please try again.",
                 "INVALID_CREDENTIALS",
                 status.value(),
                 LocalDateTime.now());

--- a/backend/src/main/java/com/pixshare/pixshareapi/exception/DelegatedAccessDeniedHandler.java
+++ b/backend/src/main/java/com/pixshare/pixshareapi/exception/DelegatedAccessDeniedHandler.java
@@ -1,0 +1,50 @@
+package com.pixshare.pixshareapi.exception;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.SerializationFeature;
+import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import org.springframework.http.HttpStatus;
+import org.springframework.security.access.AccessDeniedException;
+import org.springframework.security.web.access.AccessDeniedHandler;
+import org.springframework.stereotype.Component;
+
+import java.io.IOException;
+import java.time.LocalDateTime;
+
+@Component
+public class DelegatedAccessDeniedHandler implements AccessDeniedHandler {
+
+    private final ObjectMapper objectMapper;
+
+    public DelegatedAccessDeniedHandler() {
+        this.objectMapper = new ObjectMapper();
+
+        // Register module for Java 8 Date/Time API
+        this.objectMapper.registerModule(new JavaTimeModule());
+        // Prevent writing dates as timestamps
+        this.objectMapper.disable(SerializationFeature.WRITE_DATES_AS_TIMESTAMPS);
+    }
+
+    @Override
+    public void handle(HttpServletRequest request, HttpServletResponse response,
+                       AccessDeniedException e) throws IOException, ServletException {
+
+        HttpStatus status = HttpStatus.FORBIDDEN;
+        response.setStatus(status.value());
+        response.setContentType("application/json");
+
+        ApiError apiError = new ApiError(request.getRequestURI(),
+                "Access denied. Insufficient permissions to access this resource.",
+                "ACCESS_DENIED",
+                status.value(),
+                LocalDateTime.now()
+        );
+
+        String jsonResponse = objectMapper.writeValueAsString(apiError);
+        response.getWriter().write(jsonResponse);
+    }
+
+}

--- a/backend/src/main/java/com/pixshare/pixshareapi/exception/DelegatedAuthEntryPoint.java
+++ b/backend/src/main/java/com/pixshare/pixshareapi/exception/DelegatedAuthEntryPoint.java
@@ -1,27 +1,49 @@
 package com.pixshare.pixshareapi.exception;
 
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.SerializationFeature;
+import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
 import jakarta.servlet.ServletException;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
+import org.springframework.http.HttpStatus;
 import org.springframework.security.core.AuthenticationException;
 import org.springframework.security.web.AuthenticationEntryPoint;
 import org.springframework.stereotype.Component;
-import org.springframework.web.servlet.HandlerExceptionResolver;
 
 import java.io.IOException;
+import java.time.LocalDateTime;
 
 @Component
 public class DelegatedAuthEntryPoint implements AuthenticationEntryPoint {
 
-    private final HandlerExceptionResolver handlerExceptionResolver;
+    private final ObjectMapper objectMapper;
 
-    public DelegatedAuthEntryPoint(HandlerExceptionResolver handlerExceptionResolver) {
-        this.handlerExceptionResolver = handlerExceptionResolver;
+    public DelegatedAuthEntryPoint() {
+        this.objectMapper = new ObjectMapper();
+
+        // Register module for Java 8 Date/Time API
+        this.objectMapper.registerModule(new JavaTimeModule());
+        // Prevent writing dates as timestamps
+        this.objectMapper.disable(SerializationFeature.WRITE_DATES_AS_TIMESTAMPS);
     }
 
     @Override
-    public void commence(HttpServletRequest request, HttpServletResponse response, AuthenticationException authException) throws IOException, ServletException {
-        handlerExceptionResolver.resolveException(request, response, null, authException);
+    public void commence(HttpServletRequest request, HttpServletResponse response,
+                         AuthenticationException e) throws IOException, ServletException {
+
+        HttpStatus status = HttpStatus.UNAUTHORIZED;
+        response.setStatus(status.value());
+        response.setContentType("application/json");
+
+        ApiError apiError = new ApiError(request.getRequestURI(),
+                e.getMessage(),
+                "INSUFFICIENT_AUTHENTICATION",
+                status.value(),
+                LocalDateTime.now());
+
+        String jsonResponse = objectMapper.writeValueAsString(apiError);
+        response.getWriter().write(jsonResponse);
     }
-    
+
 }

--- a/backend/src/main/java/com/pixshare/pixshareapi/security/SecurityFilterChainConfig.java
+++ b/backend/src/main/java/com/pixshare/pixshareapi/security/SecurityFilterChainConfig.java
@@ -1,6 +1,7 @@
 package com.pixshare.pixshareapi.security;
 
 import com.pixshare.pixshareapi.jwt.JWTAuthenticationFilter;
+import com.pixshare.pixshareapi.user.RoleName;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.http.HttpMethod;
@@ -8,9 +9,11 @@ import org.springframework.security.authentication.AuthenticationProvider;
 import org.springframework.security.config.Customizer;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
+import org.springframework.security.config.annotation.web.configurers.AbstractHttpConfigurer;
 import org.springframework.security.config.http.SessionCreationPolicy;
 import org.springframework.security.web.AuthenticationEntryPoint;
 import org.springframework.security.web.SecurityFilterChain;
+import org.springframework.security.web.access.AccessDeniedHandler;
 import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
 
 @Configuration
@@ -21,46 +24,43 @@ public class SecurityFilterChainConfig {
 
     private final AuthenticationEntryPoint authenticationEntryPoint;
 
+    private final AccessDeniedHandler accessDeniedHandler;
+
     private final JWTAuthenticationFilter jwtAuthenticationFilter;
 
-    public SecurityFilterChainConfig(AuthenticationProvider authenticationProvider, AuthenticationEntryPoint authenticationEntryPoint, JWTAuthenticationFilter jwtAuthenticationFilter) {
+    public SecurityFilterChainConfig(AuthenticationProvider authenticationProvider, AuthenticationEntryPoint authenticationEntryPoint, AccessDeniedHandler accessDeniedHandler, JWTAuthenticationFilter jwtAuthenticationFilter) {
         this.authenticationProvider = authenticationProvider;
         this.authenticationEntryPoint = authenticationEntryPoint;
+        this.accessDeniedHandler = accessDeniedHandler;
         this.jwtAuthenticationFilter = jwtAuthenticationFilter;
     }
 
     @Bean
     public SecurityFilterChain securityFilterChain(HttpSecurity http) throws Exception {
-        http.csrf().disable()
+        http.csrf(AbstractHttpConfigurer::disable)
                 .cors(Customizer.withDefaults())
-                .authorizeHttpRequests()
-                .requestMatchers(HttpMethod.POST,
-                        "/api/v1/auth/signup",
-                        "/api/v1/auth/login")
-                .permitAll()
-                .requestMatchers(HttpMethod.GET,
-                        "/api/v1/users/public/**",
-                        "/api/v1/posts/public/**")
-                .permitAll()
-                .requestMatchers(HttpMethod.GET, "/api/v1/users/account/password/reset/**")
-                .permitAll()
-                .requestMatchers(HttpMethod.POST, "/api/v1/users/account/password/reset/**")
-                .permitAll()
-                .requestMatchers(HttpMethod.PUT, "/api/v1/users/account/password/reset")
-                .permitAll()
-                .requestMatchers(HttpMethod.GET,
-                        "/actuator/**")
-                .permitAll()
-                .anyRequest()
-                .authenticated()
-                .and()
-                .sessionManagement()
-                .sessionCreationPolicy(SessionCreationPolicy.STATELESS)
-                .and()
+                .authorizeHttpRequests(auth -> auth
+                        .requestMatchers(HttpMethod.POST,
+                                "/api/v1/auth/signup",
+                                "/api/v1/auth/login").permitAll()
+                        .requestMatchers(HttpMethod.GET,
+                                "/api/v1/users/public/**",
+                                "/api/v1/posts/public/**").permitAll()
+                        .requestMatchers(HttpMethod.GET, "/api/v1/users/account/password/reset/**").permitAll()
+                        .requestMatchers(HttpMethod.POST, "/api/v1/users/account/password/reset/**").permitAll()
+                        .requestMatchers(HttpMethod.PUT, "/api/v1/users/account/password/reset").permitAll()
+                        .requestMatchers(HttpMethod.GET, "/actuator/**").permitAll()
+                        .requestMatchers("/api/v1/admin/**").hasRole(RoleName.ADMIN.name())
+                        .anyRequest().authenticated()
+                )
+                .sessionManagement(session -> session
+                        .sessionCreationPolicy(SessionCreationPolicy.STATELESS))
                 .authenticationProvider(authenticationProvider)
                 .addFilterBefore(jwtAuthenticationFilter, UsernamePasswordAuthenticationFilter.class)
-                .exceptionHandling()
-                .authenticationEntryPoint(authenticationEntryPoint);
+                .exceptionHandling(ex -> ex
+                        .authenticationEntryPoint(authenticationEntryPoint)
+                        .accessDeniedHandler(accessDeniedHandler)
+                );
 
         return http.build();
     }


### PR DESCRIPTION
### Type:

Enhancement

### Description:

This PR improves the authentication error handling and security configuration in the backend of the application. It introduces custom handlers for authentication failures and access denial scenarios, ensuring consistent and informative JSON responses for all security-related errors. The implementation also includes role-based access control for admin endpoints and updates the HTTP status codes to align with standard REST practices.

### Main Files Walkthrough:

<details>
  <summary>files:</summary>
  
- `backend/src/main/java/com/pixshare/pixshareapi/exception/DefaultExceptionHandler.java`:
   - Changed HTTP status for `InsufficientAuthenticationException` from FORBIDDEN to UNAUTHORIZED.
   - Updated error message for `BadCredentialsException` to provide clearer feedback on invalid credentials.

- `backend/src/main/java/com/pixshare/pixshareapi/exception/DelegatedAuthEntryPoint.java`:
   - Implemented AuthenticationEntryPoint to return JSON response with error details on authentication failure.
   - Configured ObjectMapper to handle Java 8 Date/Time API and disable date timestamps.
   - Included error message, status code, request URI, and timestamp in the response.

- `backend/src/main/java/com/pixshare/pixshareapi/exception/DelegatedAccessDeniedHandler.java`:
   - Implemented custom handler to return JSON response with error details on access denial.
   - Configured ObjectMapper to handle Java 8 Date/Time API and disable date timestamps.
   - Provided detailed error message, status code, and timestamp in the response.

- `backend/src/main/java/com/pixshare/pixshareapi/security/SecurityFilterChainConfig.java`:
   - Added role-based access control for admin endpoints with `RoleName.ADMIN`.
   - Refactored HTTP security configurations for cleaner syntax using lambdas.
   - Integrated `AccessDeniedHandler` for handling access denial scenarios explicitly.
</details>